### PR TITLE
Branch tag filter commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
   # publish-dev goes here: see workflow
   # trigger-integration goes here: see workflow
 
-  trigger-test-filtered-jobs:
-    executor:
+  # trigger-test-filtered-jobs:
+  #   executor:
 
   test-orb-commands:
     executor: macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ integration-master_filters: &integration-master_filters
     only: /master-.*/
 
 prod-deploy_requires: &prod-deploy_requires
-  [test-orb-commands-master, introspect-orbs-master]
+  [test-orb-commands-master, introspect-orbs-master, filtered-run-tests_only-branch-master, filtered-run-tests_ignore-branch-master, filtered-run-tests_only-tag-master, filtered-run-tests_ignore-tag-master]
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -290,12 +290,16 @@ workflows:
           filters:
             branches:
               only: filtered-run-tests_only-branch-master
+          post-steps:
+            - filtered-run-tests_only-branch
 
       - filtered-run-tests:
           name: filtered-run-tests_ignore-branch-master
           filters:
             branches:
               only: filtered-run-tests_ignore-branch-master
+          post-steps:
+            - filtered-run-tests_ignore-branch
 
       - filtered-run-tests:
           name: filtered-run-tests_only-tag-master
@@ -304,6 +308,8 @@ workflows:
               ignore: /.*/
             tags:
               only: filtered-run-tests_only-tag-master
+          post-steps:
+            - filtered-run-tests_only-tag
 
       - filtered-run-tests:
           name: filtered-run-tests_ignore-tag-master
@@ -312,6 +318,8 @@ workflows:
               ignore: /.*/
             tags:
               only: filtered-run-tests_ignore-tag-master
+          post-steps:
+            - filtered-run-tests_ignore-tag
 
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ commands:
   filtered-run-tests_only-branch:
     steps:
       - build-tools/run-filtered:
-          only-branch: /filtered-run-tests_only-branch.*/
+          only-branch: /filtered-run-tests_only-branchx.*/
           ignore-branch: /filtered-run-tests_only-branch.*/
           steps:
             - run:
-                name: should run
+                name: shouldn't run
                 command: echo "testing"
 
   filtered-run-tests_ignore-branch:
@@ -27,11 +27,11 @@ commands:
   filtered-run-tests_only-tag:
     steps:
       - build-tools/run-filtered:
-          only-tag: /filtered-run-tests_only-tag.*/
+          only-tag: /filtered-run-tests_only-tagx.*/
           ignore-tag: /filtered-run-tests_only-tag.*/
           steps:
             - run:
-                name: should run
+                name: shouldn't run
                 command: echo "testing"
 
   filtered-run-tests_ignore-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,9 @@ workflows:
           name: introspect-orbs-dev
           filters: *integration-dev_filters
 
-      - trigger-filtered-run-test-jobs:
-          name: trigger-filtered-run-test-jobs-dev
-          filters: *integration-dev_filters
+      # - trigger-filtered-run-test-jobs:
+      #     name: trigger-filtered-run-test-jobs-dev
+      #     filters: *integration-dev_filters
 
       # triggered by master branch commits
       - test-orb-commands:
@@ -222,9 +222,9 @@ workflows:
           name: introspect-orbs-master
           filters: *integration-master_filters
 
-      - trigger-filtered-run-test-jobs:
-          name: trigger-filtered-run-test-jobs-master
-          filters: *integration-master_filters
+      # - trigger-filtered-run-test-jobs:
+      #     name: trigger-filtered-run-test-jobs-master
+      #     filters: *integration-master_filters
 
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,48 +36,20 @@ jobs:
   #           git checkout -b filtered-run-tests
   #           git push origin filtered-run-tests
 
-  trigger-filtered-run-test-jobs:
-    executor: build-tools/ci-base
-    steps:
-      - checkout
+  # trigger-filtered-run-test-jobs:
+  #   executor: build-tools/ci-base
+  #   steps:
+  #     - checkout
 
-      - add_ssh_keys:
-          fingerprints:
-            - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
 
-      - run:
-          name: git config
-          command: |
-            git config --global user.name "$CIRCLE_USERNAME"
-            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-
-      - run:
-          name: push only-branch branch
-          command: |
-            MAIN_BRANCH="$CIRCLE_BRANCH"
-            git checkout -b filtered-run-tests_only-branch
-            git push origin filtered-run-tests_only-branch
-            git checkout "$MAIN_BRANCH"
-
-      - run:
-          name: push ignore-branch branch
-          command: |
-            MAIN_BRANCH="$CIRCLE_BRANCH"
-            git checkout -b filtered-run-tests_ignore-branch
-            git push origin filtered-run-tests_ignore-branch
-            git checkout "$MAIN_BRANCH"
-
-      - run:
-          name: push only-tag tag
-          command: |
-            git tag filtered-run-tests_only-tag
-            git push origin filtered-run-tests_only-tag
-
-      - run:
-          name: push ignore-tag tag
-          command: |
-            git tag filtered-run-tests_ignore-tag
-            git push origin filtered-run-tests_ignore-tag
+  #     - run:
+  #         name: git config
+  #         command: |
+  #           git config --global user.name "$CIRCLE_USERNAME"
+  #           git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
 
   test-orb-commands:
     executor: build-tools/macos
@@ -156,8 +128,35 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
           ssh-fingerprints: 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
-          requires:
-            - orb-tools/publish-dev
+          requires: [orb-tools/publish-dev]
+          post-steps:
+            - run:
+                name: push only-branch branch
+                command: |
+                  MAIN_BRANCH="$CIRCLE_BRANCH"
+                  git checkout -b filtered-run-tests_only-branch
+                  git push origin filtered-run-tests_only-branch
+                  git checkout "$MAIN_BRANCH"
+
+            - run:
+                name: push ignore-branch branch
+                command: |
+                  MAIN_BRANCH="$CIRCLE_BRANCH"
+                  git checkout -b filtered-run-tests_ignore-branch
+                  git push origin filtered-run-tests_ignore-branch
+                  git checkout "$MAIN_BRANCH"
+
+            - run:
+                name: push only-tag tag
+                command: |
+                  git tag filtered-run-tests_only-tag
+                  git push origin filtered-run-tests_only-tag
+
+            - run:
+                name: push ignore-tag tag
+                command: |
+                  git tag filtered-run-tests_ignore-tag
+                  git push origin filtered-run-tests_ignore-tag
           filters:
             branches:
               ignore: master
@@ -166,8 +165,35 @@ workflows:
           name: trigger-integration-master
           ssh-fingerprints: 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
           tag: master
-          requires:
-            - orb-tools/publish-dev
+          requires: [orb-tools/publish-dev]
+          post-steps:
+            - run:
+                name: push only-branch branch
+                command: |
+                  MAIN_BRANCH="$CIRCLE_BRANCH"
+                  git checkout -b filtered-run-tests_only-branch
+                  git push origin filtered-run-tests_only-branch
+                  git checkout "$MAIN_BRANCH"
+
+            - run:
+                name: push ignore-branch branch
+                command: |
+                  MAIN_BRANCH="$CIRCLE_BRANCH"
+                  git checkout -b filtered-run-tests_ignore-branch
+                  git push origin filtered-run-tests_ignore-branch
+                  git checkout "$MAIN_BRANCH"
+
+            - run:
+                name: push only-tag tag
+                command: |
+                  git tag filtered-run-tests_only-tag
+                  git push origin filtered-run-tests_only-tag
+
+            - run:
+                name: push ignore-tag tag
+                command: |
+                  git tag filtered-run-tests_ignore-tag
+                  git push origin filtered-run-tests_ignore-tag
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,9 @@ workflows:
   lint_pack-validate_publish-dev:
     jobs:
       - orb-tools/lint:
-          branches:
-            ignore: /filtered-run-tests*/
+          filters:
+            branches:
+              ignore: /filtered-run-tests*/
 
       - orb-tools/pack:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  orb-tools: circleci/orb-tools@7.0.0
+  orb-tools: circleci/orb-tools@7.3.0
 
 executors:
   macos:
@@ -14,6 +14,9 @@ jobs:
   # validate goes here: see workflow
   # publish-dev goes here: see workflow
   # trigger-integration goes here: see workflow
+
+  trigger-test-filtered-jobs:
+    executor:
 
   test-orb-commands:
     executor: macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,72 @@ jobs:
   # publish-dev goes here: see workflow
   # trigger-integration goes here: see workflow
 
-  # trigger-test-filtered-jobs:
-  #   executor:
+  # trigger-filtered-run-tests-workflow:
+  #   executor: build-tools/ci-base
+  #   steps:
+  #     - checkout
+
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
+
+  #     - run:
+  #         name: git config
+  #         command: |
+  #           git config --global user.name "$CIRCLE_USERNAME"
+  #           git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+
+  #     - run:
+  #         name: push special filtered-run-tests branch
+  #         command: |
+  #           git checkout -b filtered-run-tests
+  #           git push origin filtered-run-tests
+
+  trigger-filtered-run-test-jobs:
+    executor: build-tools/ci-base
+    steps:
+      - checkout
+
+      - add_ssh_keys:
+          fingerprints:
+            - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
+
+      - run:
+          name: git config
+          command: |
+            git config --global user.name "$CIRCLE_USERNAME"
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+
+      - run:
+          name: push only-branch branch
+          command: |
+            MAIN_BRANCH="$CIRCLE_BRANCH"
+            git checkout -b filtered-run-tests_only-branch
+            git push origin filtered-run-tests_only-branch
+            git checkout "$MAIN_BRANCH"
+
+      - run:
+          name: push ignore-branch branch
+          command: |
+            MAIN_BRANCH="$CIRCLE_BRANCH"
+            git checkout -b filtered-run-tests_ignore-branch
+            git push origin filtered-run-tests_ignore-branch
+            git checkout "$MAIN_BRANCH"
+
+      - run:
+          name: push only-tag tag
+          command: |
+            git tag filtered-run-tests_only-tag
+            git push origin filtered-run-tests_only-tag
+
+      - run:
+          name: push ignore-tag tag
+          command: |
+            git tag filtered-run-tests_ignore-tag
+            git push origin filtered-run-tests_ignore-tag
 
   test-orb-commands:
-    executor: macos
+    executor: build-tools/macos
     steps:
       - checkout
 
@@ -77,7 +138,9 @@ prod-deploy_requires: &prod-deploy_requires
 workflows:
   lint_pack-validate_publish-dev:
     jobs:
-      - orb-tools/lint
+      - orb-tools/lint:
+          branches:
+            ignore: /filtered-run-tests*/
 
       - orb-tools/pack:
           requires:
@@ -119,6 +182,10 @@ workflows:
           name: introspect-orbs-dev
           filters: *integration-dev_filters
 
+      - trigger-filtered-run-test-jobs:
+          name: trigger-filtered-run-test-jobs-dev
+          filters: *integration-dev_filters
+
       # triggered by master branch commits
       - test-orb-commands:
           name: test-orb-commands-master
@@ -126,6 +193,10 @@ workflows:
 
       - build-tools/introspect-orbs:
           name: introspect-orbs-master
+          filters: *integration-master_filters
+
+      - trigger-filtered-run-test-jobs:
+          name: trigger-filtered-run-test-jobs-master
           filters: *integration-master_filters
 
       # patch, minor, or major publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ executors:
       xcode: "10.1.0"
 
 jobs:
+  filtered-run-tests:
+    executor: build-tools/ci-base
+    steps:
+      - checkout
+
   test-orb-commands:
     executor: build-tools/macos
     steps:
@@ -102,6 +107,21 @@ workflows:
                   git push origin --delete $(git tag -l) # Pushing once should be faster than multiple times
                   git tag -d $(git tag -l)
 
+            - run:
+                name: cleanup filtered-run-tests branches, too
+                command: |
+                  git branch -d filtered-run-tests_only-branch-dev
+                  git push origin --delete filtered-run-tests_only-branch-dev
+
+                  git branch -d filtered-run-tests_only-branch-master
+                  git push origin --delete filtered-run-tests_only-branch-master
+
+                  git branch -d filtered-run-tests_ignore-branch-dev
+                  git push origin --delete filtered-run-tests_ignore-branch-dev
+
+                  git branch -d filtered-run-tests_ignore-branch-master
+                  git push origin --delete filtered-run-tests_ignore-branch-master
+
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
           ssh-fingerprints: 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
@@ -111,29 +131,29 @@ workflows:
                 name: push only-branch branch
                 command: |
                   MAIN_BRANCH="$CIRCLE_BRANCH"
-                  git checkout -b filtered-run-tests_only-branch
-                  git push origin filtered-run-tests_only-branch
+                  git checkout -b filtered-run-tests_only-branch-dev
+                  git push origin filtered-run-tests_only-branch-dev
                   git checkout "$MAIN_BRANCH"
 
             - run:
                 name: push ignore-branch branch
                 command: |
                   MAIN_BRANCH="$CIRCLE_BRANCH"
-                  git checkout -b filtered-run-tests_ignore-branch
-                  git push origin filtered-run-tests_ignore-branch
+                  git checkout -b filtered-run-tests_ignore-branch-dev
+                  git push origin filtered-run-tests_ignore-branch-dev
                   git checkout "$MAIN_BRANCH"
 
             - run:
                 name: push only-tag tag
                 command: |
-                  git tag filtered-run-tests_only-tag
-                  git push origin filtered-run-tests_only-tag
+                  git tag filtered-run-tests_only-tag-dev
+                  git push origin filtered-run-tests_only-tag-dev
 
             - run:
                 name: push ignore-tag tag
                 command: |
-                  git tag filtered-run-tests_ignore-tag
-                  git push origin filtered-run-tests_ignore-tag
+                  git tag filtered-run-tests_ignore-tag-dev
+                  git push origin filtered-run-tests_ignore-tag-dev
           filters:
             branches:
               ignore: master
@@ -148,29 +168,29 @@ workflows:
                 name: push only-branch branch
                 command: |
                   MAIN_BRANCH="$CIRCLE_BRANCH"
-                  git checkout -b filtered-run-tests_only-branch
-                  git push origin filtered-run-tests_only-branch
+                  git checkout -b filtered-run-tests_only-branch-master
+                  git push origin filtered-run-tests_only-branch-master
                   git checkout "$MAIN_BRANCH"
 
             - run:
                 name: push ignore-branch branch
                 command: |
                   MAIN_BRANCH="$CIRCLE_BRANCH"
-                  git checkout -b filtered-run-tests_ignore-branch
-                  git push origin filtered-run-tests_ignore-branch
+                  git checkout -b filtered-run-tests_ignore-branch-master
+                  git push origin filtered-run-tests_ignore-branch-master
                   git checkout "$MAIN_BRANCH"
 
             - run:
                 name: push only-tag tag
                 command: |
-                  git tag filtered-run-tests_only-tag
-                  git push origin filtered-run-tests_only-tag
+                  git tag filtered-run-tests_only-tag-master
+                  git push origin filtered-run-tests_only-tag-master
 
             - run:
                 name: push ignore-tag tag
                 command: |
-                  git tag filtered-run-tests_ignore-tag
-                  git push origin filtered-run-tests_ignore-tag
+                  git tag filtered-run-tests_ignore-tag-master
+                  git push origin filtered-run-tests_ignore-tag-master
           filters:
             branches:
               only: master
@@ -185,6 +205,12 @@ workflows:
       - build-tools/introspect-orbs:
           name: introspect-orbs-dev
           filters: *integration-dev_filters
+
+      - filtered-run-tests:
+          name: filtered-run-tests_only-branch-dev
+          filters:
+            branches:
+              only: filtered-run-tests_only-branch-dev
 
       # triggered by master branch commits
       - test-orb-commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,8 +189,6 @@ workflows:
                   git tag filtered-run-tests_ignore-tag-dev
                   git push origin filtered-run-tests_ignore-tag-dev
           cleanup-tags: true
-          requires:
-            - orb-tools/publish-dev
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,28 @@ workflows:
             branches:
               only: filtered-run-tests_only-branch-dev
 
+      - filtered-run-tests:
+          name: filtered-run-tests_ignore-branch-dev
+          filters:
+            branches:
+              only: filtered-run-tests_ignore-branch-dev
+
+      - filtered-run-tests:
+          name: filtered-run-tests_only-tag-dev
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: filtered-run-tests_only-tag-dev
+
+      - filtered-run-tests:
+          name: filtered-run-tests_ignore-tag-dev
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: filtered-run-tests_ignore-tag-dev
+
       # triggered by master branch commits
       - test-orb-commands:
           name: test-orb-commands-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  orb-tools: circleci/orb-tools@8.1.0
+  orb-tools: circleci/orb-tools@8.2.0
 
 commands:
   filtered-run-tests_only-branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  orb-tools: circleci/orb-tools@8.2.0
+  orb-tools: circleci/orb-tools@8.3.0
 
 commands:
   filtered-run-tests_only-branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ workflows:
                 command: |
                   git tag -d $(git tag -l)
                   git fetch
-                  git push origin --delete $(git tag -l) # Pushing once should be faster than multiple times
+                  git push origin --delete $(git tag -l) || true
                   git tag -d $(git tag -l)
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ commands:
     steps:
       - build-tools/run-filtered:
           only-branch: /filtered-run-tests_only-branch.*/
+          ignore-branch: /filtered-run-tests_only-branch.*/
           steps:
             - run:
                 name: should run
@@ -17,16 +18,17 @@ commands:
   filtered-run-tests_ignore-branch:
     steps:
       - build-tools/run-filtered:
-          ignore-branch: /filtered-run-tests_ignore-branch.*/
+          ignore-branch: /filtered-run-tests_ignore-branchx.*/
           steps:
             - run:
-                name: shouldn't run
+                name: should run
                 command: echo "testing"
 
   filtered-run-tests_only-tag:
     steps:
       - build-tools/run-filtered:
           only-tag: /filtered-run-tests_only-tag.*/
+          ignore-tag: /filtered-run-tests_only-tag.*/
           steps:
             - run:
                 name: should run
@@ -35,10 +37,10 @@ commands:
   filtered-run-tests_ignore-tag:
     steps:
       - build-tools/run-filtered:
-          ignore-tag: /filtered-run-tests_ignore-tag.*/
+          ignore-tag: /filtered-run-tests_ignore-tagx.*/
           steps:
             - run:
-                name: shouldn't run
+                name: should run
                 command: echo "testing"
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,42 @@ orbs:
   build-tools: circleci/build-tools@dev:alpha
   orb-tools: circleci/orb-tools@7.3.0
 
-executors:
-  macos:
-    macos:
-      xcode: "10.1.0"
+commands:
+  filtered-run-tests_only-branch:
+    steps:
+      - build-tools/run-filtered:
+          only-branch: /filtered-run-tests_only-branch.*/
+          steps:
+            - run:
+                name: should run
+                command: echo "testing"
+
+  filtered-run-tests_ignore-branch:
+    steps:
+      - build-tools/run-filtered:
+          ignore-branch: /filtered-run-tests_ignore-branch.*/
+          steps:
+            - run:
+                name: shouldn't run
+                command: echo "testing"
+
+  filtered-run-tests_only-tag:
+    steps:
+      - build-tools/run-filtered:
+          only-tag: /filtered-run-tests_only-tag.*/
+          steps:
+            - run:
+                name: should run
+                command: echo "testing"
+
+  filtered-run-tests_ignore-tag:
+    steps:
+      - build-tools/run-filtered:
+          ignore-tag: /filtered-run-tests_ignore-tag.*/
+          steps:
+            - run:
+                name: shouldn't run
+                command: echo "testing"
 
 jobs:
   filtered-run-tests:
@@ -211,12 +243,16 @@ workflows:
           filters:
             branches:
               only: filtered-run-tests_only-branch-dev
+          post-steps:
+            - filtered-run-tests_only-branch
 
       - filtered-run-tests:
           name: filtered-run-tests_ignore-branch-dev
           filters:
             branches:
               only: filtered-run-tests_ignore-branch-dev
+          post-steps:
+            - filtered-run-tests_ignore-branch
 
       - filtered-run-tests:
           name: filtered-run-tests_only-tag-dev
@@ -225,6 +261,8 @@ workflows:
               ignore: /.*/
             tags:
               only: filtered-run-tests_only-tag-dev
+          post-steps:
+            - filtered-run-tests_only-tag
 
       - filtered-run-tests:
           name: filtered-run-tests_ignore-tag-dev
@@ -233,6 +271,8 @@ workflows:
               ignore: /.*/
             tags:
               only: filtered-run-tests_ignore-tag-dev
+          post-steps:
+            - filtered-run-tests_ignore-tag
 
       # triggered by master branch commits
       - test-orb-commands:
@@ -242,6 +282,34 @@ workflows:
       - build-tools/introspect-orbs:
           name: introspect-orbs-master
           filters: *integration-master_filters
+
+      - filtered-run-tests:
+          name: filtered-run-tests_only-branch-master
+          filters:
+            branches:
+              only: filtered-run-tests_only-branch-master
+
+      - filtered-run-tests:
+          name: filtered-run-tests_ignore-branch-master
+          filters:
+            branches:
+              only: filtered-run-tests_ignore-branch-master
+
+      - filtered-run-tests:
+          name: filtered-run-tests_only-tag-master
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: filtered-run-tests_only-tag-master
+
+      - filtered-run-tests:
+          name: filtered-run-tests_ignore-tag-master
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: filtered-run-tests_ignore-tag-master
 
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,47 +10,6 @@ executors:
       xcode: "10.1.0"
 
 jobs:
-  # lint goes here: see workflow
-  # validate goes here: see workflow
-  # publish-dev goes here: see workflow
-  # trigger-integration goes here: see workflow
-
-  # trigger-filtered-run-tests-workflow:
-  #   executor: build-tools/ci-base
-  #   steps:
-  #     - checkout
-
-      # - add_ssh_keys:
-      #     fingerprints:
-      #       - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
-
-      # - run:
-      #     name: git config
-      #     command: |
-      #       git config --global user.name "$CIRCLE_USERNAME"
-      #       git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-
-  #     - run:
-  #         name: push special filtered-run-tests branch
-  #         command: |
-  #           git checkout -b filtered-run-tests
-  #           git push origin filtered-run-tests
-
-  # trigger-filtered-run-test-jobs:
-  #   executor: build-tools/ci-base
-  #   steps:
-  #     - checkout
-
-  #     - add_ssh_keys:
-  #         fingerprints:
-  #           - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
-
-  #     - run:
-  #         name: git config
-  #         command: |
-  #           git config --global user.name "$CIRCLE_USERNAME"
-  #           git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-
   test-orb-commands:
     executor: build-tools/macos
     steps:
@@ -124,6 +83,8 @@ workflows:
           orb-name: circleci/build-tools
           requires: [orb-tools/pack]
           post-steps:
+            - checkout
+
             - add_ssh_keys:
                 fingerprints:
                   - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
@@ -226,10 +187,6 @@ workflows:
           name: introspect-orbs-dev
           filters: *integration-dev_filters
 
-      # - trigger-filtered-run-test-jobs:
-      #     name: trigger-filtered-run-test-jobs-dev
-      #     filters: *integration-dev_filters
-
       # triggered by master branch commits
       - test-orb-commands:
           name: test-orb-commands-master
@@ -238,10 +195,6 @@ workflows:
       - build-tools/introspect-orbs:
           name: introspect-orbs-master
           filters: *integration-master_filters
-
-      # - trigger-filtered-run-test-jobs:
-      #     name: trigger-filtered-run-test-jobs-master
-      #     filters: *integration-master_filters
 
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ workflows:
       - orb-tools/lint:
           filters:
             branches:
-              ignore: /filtered-run-tests*/
+              ignore: /filtered-run-tests.*/
 
       - orb-tools/pack:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,16 +133,16 @@ workflows:
                   git config --global user.name "$CIRCLE_USERNAME"
                   git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
 
-            - run:
-                name: cleanup any existing tags, to prep for next job
-                command: |
-                  git tag -d $(git tag -l)
-                  git fetch
-                  git push origin --delete $(git tag -l) || true
-                  git tag -d $(git tag -l)
+            # - run:
+            #     name: cleanup any existing tags, to prep for next job
+            #     command: |
+            #       git tag -d $(git tag -l)
+            #       git fetch
+            #       git push origin --delete $(git tag -l) || true
+            #       git tag -d $(git tag -l)
 
             - run:
-                name: cleanup filtered-run-tests branches, too, if they exist
+                name: cleanup filtered-run-tests branches, if they exist
                 command: |
                   git branch -d filtered-run-tests_only-branch-dev || true
                   git push origin --delete filtered-run-tests_only-branch-dev || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,15 @@ jobs:
   #   steps:
   #     - checkout
 
-  #     - add_ssh_keys:
-  #         fingerprints:
-  #           - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
+      # - add_ssh_keys:
+      #     fingerprints:
+      #       - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
 
-  #     - run:
-  #         name: git config
-  #         command: |
-  #           git config --global user.name "$CIRCLE_USERNAME"
-  #           git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+      # - run:
+      #     name: git config
+      #     command: |
+      #       git config --global user.name "$CIRCLE_USERNAME"
+      #       git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
 
   #     - run:
   #         name: push special filtered-run-tests branch
@@ -122,8 +122,25 @@ workflows:
       - orb-tools/publish-dev:
           context: orb-publishing
           orb-name: circleci/build-tools
-          requires:
-            - orb-tools/pack
+          requires: [orb-tools/pack]
+          post-steps:
+            - add_ssh_keys:
+                fingerprints:
+                  - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
+
+            - run:
+                name: git config
+                command: |
+                  git config --global user.name "$CIRCLE_USERNAME"
+                  git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+
+            - run:
+                name: cleanup any existing tags, to prep for next job
+                command: |
+                  git tag -d $(git tag -l)
+                  git fetch
+                  git push origin --delete $(git tag -l) # Pushing once should be faster than multiple times
+                  git tag -d $(git tag -l)
 
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,10 @@ workflows:
 
       - orb-tools/publish-dev:
           context: orb-publishing
+          checkout: true
           orb-name: circleci/build-tools
           requires: [orb-tools/pack]
           post-steps:
-            - checkout
-
             - add_ssh_keys:
                 fingerprints:
                   - 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  orb-tools: circleci/orb-tools@7.3.0
+  orb-tools: circleci/orb-tools@8.1.0
 
 commands:
   filtered-run-tests_only-branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,19 +108,19 @@ workflows:
                   git tag -d $(git tag -l)
 
             - run:
-                name: cleanup filtered-run-tests branches, too
+                name: cleanup filtered-run-tests branches, too, if they exist
                 command: |
-                  git branch -d filtered-run-tests_only-branch-dev
-                  git push origin --delete filtered-run-tests_only-branch-dev
+                  git branch -d filtered-run-tests_only-branch-dev || true
+                  git push origin --delete filtered-run-tests_only-branch-dev || true
 
-                  git branch -d filtered-run-tests_only-branch-master
-                  git push origin --delete filtered-run-tests_only-branch-master
+                  git branch -d filtered-run-tests_only-branch-master || true
+                  git push origin --delete filtered-run-tests_only-branch-master || true
 
-                  git branch -d filtered-run-tests_ignore-branch-dev
-                  git push origin --delete filtered-run-tests_ignore-branch-dev
+                  git branch -d filtered-run-tests_ignore-branch-dev || true
+                  git push origin --delete filtered-run-tests_ignore-branch-dev || true
 
-                  git branch -d filtered-run-tests_ignore-branch-master
-                  git push origin --delete filtered-run-tests_ignore-branch-master
+                  git branch -d filtered-run-tests_ignore-branch-master || true
+                  git push origin --delete filtered-run-tests_ignore-branch-master || true
 
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 ### Checklist
 
 <!--
-	thank you for contributing to CircleCI Orbs!
-	before submitting your a request, please go through the following
-	items and place an x in the [ ] if they have been completed
+  thank you for contributing to CircleCI Orbs!
+  before submitting your a request, please go through the following
+  items and place an x in the [ ] if they have been completed
 -->
 
 - [ ] All new jobs, commands, executors, parameters have descriptions
@@ -13,7 +13,7 @@
 ### Motivation, issues
 
 <!---
-	why is this change required? what problem does it solve?
+  why is this change required? what problem does it solve?
   paste links to any relevant GitHub issues filed against
   this repository that this pull request addresses
 -->

--- a/publish-alpha.sh
+++ b/publish-alpha.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+circleci config pack src > orb.yml
+circleci orb publish orb.yml circleci/build-tools@dev:alpha
+rm -rf orb.yml

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -64,7 +64,7 @@ steps:
   - run:
       name: evaluate branch/tag filters
       command: |
-        BRANCH_ONLY="<<parameters.only-branch>>"
+        BRANCH_ONLY=<<parameters.only-branch>>
         # check if we got a regex or an exact name
         if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
@@ -81,7 +81,7 @@ steps:
           fi
         fi
 
-        BRANCH_IGNORE="<<parameters.ignore-branch>>"
+        BRANCH_IGNORE=<<parameters.ignore-branch>>
         # check if we got a regex or an exact name
         if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
@@ -98,7 +98,7 @@ steps:
           fi
         fi
 
-        TAG_ONLY="<<parameters.only-tag>>"
+        TAG_ONLY=<<parameters.only-tag>>
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
@@ -115,7 +115,7 @@ steps:
           fi
         fi
 
-        TAG_IGNORE="<<parameters.ignore-tag>>"
+        TAG_IGNORE=<<parameters.ignore-tag>>
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -64,7 +64,6 @@ steps:
   - run:
       name: evaluate branch/tag filters
       command: |
-        BRANCH_MATCH=true
         BRANCH_ONLY=<<parameters.only-branch>>
 
         # check if we got a regex or an exact name
@@ -77,6 +76,9 @@ steps:
 
             BRANCH_MATCH=false
             circleci step halt
+          else
+            BRANCH_MATCH=true
+            echo "branch matches branch-only regex!"
           fi
         else # exact name
           if [[ "$CIRCLE_BRANCH" != "$BRANCH_ONLY" ]]; then
@@ -84,17 +86,21 @@ steps:
 
             BRANCH_MATCH=false
             circleci step halt
+          else
+            BRANCH_MATCH=true
+            echo "branch matches branch-only exact name!"
           fi
         fi
 
         # skip branch-ignore if we already know branch-only doesn't match
         if [[ $BRANCH_MATCH == true ]]; then
           BRANCH_IGNORE=<<parameters.ignore-branch>>
+
           # check if we got a regex or an exact name
           if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
             STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
 
-            # skip if our regex is empty (//)
+            # skip if our branch regex is empty (//)
             if [ ! -z "$STRIP_SLASHES2" ]; then
               echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
@@ -111,7 +117,6 @@ steps:
           fi
         fi
 
-        TAG_MATCH=true
         TAG_ONLY=<<parameters.only-tag>>
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
@@ -123,6 +128,9 @@ steps:
 
             TAG_MATCH=false
             circleci step halt
+          else
+            TAG_MATCH=true
+            echo "tag matches tag-only regex!"
           fi
         else # exact name
           if [[ "$CIRCLE_TAG" != "$TAG_ONLY" ]]; then
@@ -130,19 +138,27 @@ steps:
 
             TAG_MATCH=false
             circleci step halt
+          else
+            TAG_MATCH=true
+            echo "tag matches tag-only exact name!"
           fi
         fi
 
         # skip tag-ignore if we already know tag-only doesn't match
         if [[ $TAG_MATCH == true ]]; then
           TAG_IGNORE=<<parameters.ignore-tag>>
+
           # check if we got "", a regex, or an exact name
           if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
             STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
             echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
 
-            # skip if there is no tag
-            if [ ! -z "$CIRCLE_TAG" ]; then
+            # we will only get into this section if tag-only was set & matched
+            # in which case we don't want to exit, even if default ignore is all tags
+            # skip if tag-ignore value is default (/.*/)
+            # also skip if there is no tag (i.e., we're on a branch)
+
+            if [ ! -z "$CIRCLE_TAG" || "$TAG_IGNORE" == "/.*/" ]; then
               if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
                 echo "tag matches ignore regex; halting"
                 circleci step halt

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -87,7 +87,7 @@ steps:
           STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
 
           # skip if our regex is empty (//)
-          if [ ! -z "$STRIP_SLASHES2"]; then
+          if [ ! -z "$STRIP_SLASHES2" ]; then
             echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
             if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
@@ -129,7 +129,7 @@ steps:
           echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
 
           # skip if there is no tag
-          if [ ! -z "$CIRCLE_TAG"]; then
+          if [ ! -z "$CIRCLE_TAG" ]; then
             if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
               echo "tag matches ignore regex; halting"
               circleci step halt

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -88,7 +88,7 @@ steps:
         fi
 
         # skip branch-ignore if we already know branch-only doesn't match
-        if [[ $BRANCH_MATCH == true ]]
+        if [[ $BRANCH_MATCH == true ]]; then
           BRANCH_IGNORE=<<parameters.ignore-branch>>
           # check if we got a regex or an exact name
           if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
@@ -134,7 +134,7 @@ steps:
         fi
 
         # skip tag-ignore if we already know tag-only doesn't match
-        if [[ $TAG_MATCH == true ]]
+        if [[ $TAG_MATCH == true ]]; then
           TAG_IGNORE=<<parameters.ignore-tag>>
           # check if we got "", a regex, or an exact name
           if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -64,7 +64,9 @@ steps:
   - run:
       name: evaluate branch/tag filters
       command: |
+        BRANCH_MATCH=true
         BRANCH_ONLY=<<parameters.only-branch>>
+
         # check if we got a regex or an exact name
         if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
@@ -72,36 +74,44 @@ steps:
 
           if [[ ! "$CIRCLE_BRANCH" =~ $STRIP_SLASHES1 ]]; then
             echo "branch doesn't match regex; halting"
+
+            BRANCH_MATCH=false
             circleci step halt
           fi
         else # exact name
           if [[ "$CIRCLE_BRANCH" != "$BRANCH_ONLY" ]]; then
             echo "branch doesn't match exact name; halting"
+
+            BRANCH_MATCH=false
             circleci step halt
           fi
         fi
 
-        BRANCH_IGNORE=<<parameters.ignore-branch>>
-        # check if we got a regex or an exact name
-        if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
-          STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
+        # skip branch-ignore if we already know branch-only doesn't match
+        if [[ $BRANCH_MATCH == true ]]
+          BRANCH_IGNORE=<<parameters.ignore-branch>>
+          # check if we got a regex or an exact name
+          if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
+            STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
 
-          # skip if our regex is empty (//)
-          if [ ! -z "$STRIP_SLASHES2" ]; then
-            echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
+            # skip if our regex is empty (//)
+            if [ ! -z "$STRIP_SLASHES2" ]; then
+              echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
-            if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
-              echo "branch matches ignore regex; halting"
+              if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
+                echo "branch matches ignore regex; halting"
+                circleci step halt
+              fi
+            fi
+          else # exact name
+            if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then
+              echo "branch matches exact ignore name; halting"
               circleci step halt
             fi
           fi
-        else # exact name
-          if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then
-            echo "branch matches exact ignore name; halting"
-            circleci step halt
-          fi
         fi
 
+        TAG_MATCH=true
         TAG_ONLY=<<parameters.only-tag>>
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
@@ -110,32 +120,39 @@ steps:
 
           if [[ ! "$CIRCLE_TAG" =~ $STRIP_SLASHES3 ]]; then
             echo "tag doesn't match regex; halting"
+
+            TAG_MATCH=false
             circleci step halt
           fi
         else # exact name
           if [[ "$CIRCLE_TAG" != "$TAG_ONLY" ]]; then
             echo "tag doesn't match exact name; halting"
+
+            TAG_MATCH=false
             circleci step halt
           fi
         fi
 
-        TAG_IGNORE=<<parameters.ignore-tag>>
-        # check if we got "", a regex, or an exact name
-        if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
-          STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
-          echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
+        # skip tag-ignore if we already know tag-only doesn't match
+        if [[ $TAG_MATCH == true ]]
+          TAG_IGNORE=<<parameters.ignore-tag>>
+          # check if we got "", a regex, or an exact name
+          if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
+            STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
+            echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
 
-          # skip if there is no tag
-          if [ ! -z "$CIRCLE_TAG" ]; then
-            if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
-              echo "tag matches ignore regex; halting"
+            # skip if there is no tag
+            if [ ! -z "$CIRCLE_TAG" ]; then
+              if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
+                echo "tag matches ignore regex; halting"
+                circleci step halt
+              fi
+            fi
+          else  # exact name
+            if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then
+              echo "tag matches exact ignore name; halting"
               circleci step halt
             fi
-          fi
-        else  # exact name
-          if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then
-            echo "tag matches exact ignore name; halting"
-            circleci step halt
           fi
         fi
 

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -138,6 +138,9 @@ steps:
               circleci step halt
             else
               TAG_MATCH=true
+              if [[ "$TAG_ONLY" != "//" ]]; then
+                TAG_ONLY_SET=true
+              fi
               echo "tag matches tag-only regex!"
             fi
           else # exact name
@@ -169,8 +172,10 @@ steps:
               if [ ! -z "$CIRCLE_TAG" ]; then
                 if [[ "$TAG_IGNORE" != "/.*/" ]]; then
                   if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
-                    echo "tag matches ignore regex; halting"
-                    circleci step halt
+                    if [[ "$TAG_ONLY_SET" != true ]]; then
+                      echo "tag matches ignore regex; halting"
+                      circleci step halt
+                    fi
                   fi
                 fi
               fi

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -62,7 +62,7 @@ parameters:
 
 steps:
   - run:
-      name: evaluate branch/tag filters
+      name: evaluate branch filters
       command: |
         BRANCH_ONLY=<<parameters.only-branch>>
         # check if we got a regex or an exact name
@@ -102,6 +102,9 @@ steps:
           fi
         fi
 
+  - run:
+      name: evaluate tag filters
+      command: |
         TAG_ONLY=<<parameters.only-tag>>
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
@@ -125,9 +128,12 @@ steps:
           STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
           echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
 
-          if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
-            echo "tag matches ignore regex; halting"
-            circleci step halt
+          # skip if there is no tag
+          if [ ! -z "$CIRCLE_TAG"]; then
+            if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
+              echo "tag matches ignore regex; halting"
+              circleci step halt
+            fi
           fi
         else  # exact name
           if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -70,7 +70,7 @@ steps:
           STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
           echo $STRIP_SLASHES1
 
-          if [[ ! "$CIRCLE_BRANCH" =~ "$STRIP_SLASHES1" ]]; then
+          if [[ ! "$CIRCLE_BRANCH" =~ $STRIP_SLASHES1 ]]; then
             echo "branch doesn't match regex; halting"
             circleci step halt
           fi
@@ -87,7 +87,7 @@ steps:
           STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
           echo $STRIP_SLASHES2
 
-          if [[ "$CIRCLE_BRANCH" =~ "$STRIP_SLASHES2" ]]; then
+          if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
             echo "branch matches ignore regex; halting"
             circleci step halt
           fi
@@ -104,7 +104,7 @@ steps:
           STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
           echo $STRIP_SLASHES3
 
-          if [[ ! "$CIRCLE_TAG" =~ "$STRIP_SLASHES3" ]]; then
+          if [[ ! "$CIRCLE_TAG" =~ $STRIP_SLASHES3 ]]; then
             echo "tag doesn't match regex; halting"
             circleci step halt
           fi
@@ -121,7 +121,7 @@ steps:
           STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
           echo $STRIP_SLASHES4
 
-          if [[ "$CIRCLE_TAG" =~ "$STRIP_SLASHES4" ]]; then
+          if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
             echo "tag matches ignore regex; halting"
             circleci step halt
           fi

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -59,6 +59,7 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
+          echo $STRIP_SLASHES1
 
           if [[ ! "$CIRCLE_BRANCH" =~ "$STRIP_SLASHES1" ]]; then
             echo "branch doesn't match regex; halting"
@@ -75,6 +76,7 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
+          echo $STRIP_SLASHES2
 
           if [[ "$CIRCLE_BRANCH" =~ "$STRIP_SLASHES2" ]]; then
             echo "branch matches ignore regex; halting"
@@ -91,6 +93,7 @@ steps:
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
+          echo $STRIP_SLASHES3
 
           if [[ ! "$CIRCLE_TAG" =~ "$STRIP_SLASHES3" ]]; then
             echo "tag doesn't match regex; halting"
@@ -107,6 +110,7 @@ steps:
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
+          echo $STRIP_SLASHES4
 
           if [[ "$CIRCLE_TAG" =~ "$STRIP_SLASHES4" ]]; then
             echo "tag matches ignore regex; halting"

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -58,7 +58,9 @@ steps:
         BRANCH_ONLY="<<parameters.only-branch>>"
         # check if we got a regex or an exact name
         if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
-          if [[ ! "$CIRCLE_BRANCH" =~ "$BRANCH_ONLY" ]]; then
+          STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
+
+          if [[ ! "$CIRCLE_BRANCH" =~ "$STRIP_SLASHES1" ]]; then
             echo "branch doesn't match regex; halting"
             circleci step halt
           fi
@@ -72,7 +74,9 @@ steps:
         BRANCH_IGNORE="<<parameters.ignore-branch>>"
         # check if we got a regex or an exact name
         if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
-          if [[ "$CIRCLE_BRANCH" =~ "$BRANCH_ONLY" ]]; then
+          STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
+
+          if [[ "$CIRCLE_BRANCH" =~ "$STRIP_SLASHES2" ]]; then
             echo "branch matches ignore regex; halting"
             circleci step halt
           fi
@@ -86,7 +90,9 @@ steps:
         TAG_ONLY="<<parameters.only-tag>>"
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
-          if [[ ! "$CIRCLE_TAG" =~ "$TAG_ONLY" ]]; then
+          STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
+
+          if [[ ! "$CIRCLE_TAG" =~ "$STRIP_SLASHES3" ]]; then
             echo "tag doesn't match regex; halting"
             circleci step halt
           fi
@@ -100,7 +106,9 @@ steps:
         TAG_IGNORE="<<parameters.ignore-tag>>"
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
-          if [[ "$CIRCLE_TAG" =~ "$TAG_ONLY" ]]; then
+          STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
+
+          if [[ "$CIRCLE_TAG" =~ "$STRIP_SLASHES4" ]]; then
             echo "tag matches ignore regex; halting"
             circleci step halt
           fi

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -66,9 +66,9 @@ steps:
       command: |
         # check if we are in a branch or tag job
         if [ ! -z "$CIRCLE_BRANCH" ]; then
-          evaluate_branch_filters()
+          evaluate_branch_filters
         elif [ ! -z "$CIRCLE_TAG"]; then
-          evaluate_tag_filters()
+          evaluate_tag_filters
         fi
 
         evaluate_branch_filters () {

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -62,7 +62,7 @@ parameters:
 
 steps:
   - run:
-      name: evaluate branch filters
+      name: evaluate branch/tag filters
       command: |
         BRANCH_ONLY=<<parameters.only-branch>>
         # check if we got a regex or an exact name
@@ -102,9 +102,6 @@ steps:
           fi
         fi
 
-  - run:
-      name: evaluate tag filters
-      command: |
         TAG_ONLY=<<parameters.only-tag>>
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -64,114 +64,125 @@ steps:
   - run:
       name: evaluate branch/tag filters
       command: |
-        BRANCH_ONLY=<<parameters.only-branch>>
-
-        # check if we got a regex or an exact name
-        if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
-          STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
-          echo "branch only regex w/o slashes: $STRIP_SLASHES1"
-
-          if [[ ! "$CIRCLE_BRANCH" =~ $STRIP_SLASHES1 ]]; then
-            echo "branch doesn't match regex; halting"
-
-            BRANCH_MATCH=false
-            circleci step halt
-          else
-            BRANCH_MATCH=true
-            echo "branch matches branch-only regex!"
-          fi
-        else # exact name
-          if [[ "$CIRCLE_BRANCH" != "$BRANCH_ONLY" ]]; then
-            echo "branch doesn't match exact name; halting"
-
-            BRANCH_MATCH=false
-            circleci step halt
-          else
-            BRANCH_MATCH=true
-            echo "branch matches branch-only exact name!"
-          fi
+        # check if we are in a branch or tag job
+        if [ ! -z "$CIRCLE_BRANCH" ]; then
+          evaluate_branch_filters()
+        elif [ ! -z "$CIRCLE_TAG"]; then
+          evaluate_tag_filters()
         fi
 
-        # skip branch-ignore if we already know branch-only doesn't match
-        if [[ $BRANCH_MATCH == true ]]; then
-          BRANCH_IGNORE=<<parameters.ignore-branch>>
+        evaluate_branch_filters () {
+          BRANCH_ONLY=<<parameters.only-branch>>
 
           # check if we got a regex or an exact name
-          if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
-            STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
+          if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
+            STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
+            echo "branch only regex w/o slashes: $STRIP_SLASHES1"
 
-            # skip if our branch regex is empty (//)
-            if [ ! -z "$STRIP_SLASHES2" ]; then
-              echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
+            if [[ ! "$CIRCLE_BRANCH" =~ $STRIP_SLASHES1 ]]; then
+              echo "branch doesn't match regex; halting"
 
-              if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
-                echo "branch matches ignore regex; halting"
-                circleci step halt
-              fi
+              BRANCH_MATCH=false
+              circleci step halt
+            else
+              BRANCH_MATCH=true
+              echo "branch matches branch-only regex!"
             fi
           else # exact name
-            if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then
-              echo "branch matches exact ignore name; halting"
+            if [[ "$CIRCLE_BRANCH" != "$BRANCH_ONLY" ]]; then
+              echo "branch doesn't match exact name; halting"
+
+              BRANCH_MATCH=false
               circleci step halt
+            else
+              BRANCH_MATCH=true
+              echo "branch matches branch-only exact name!"
             fi
           fi
-        fi
 
-        TAG_ONLY=<<parameters.only-tag>>
-        # check if we got "", a regex, or an exact name
-        if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
-          STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
-          echo "tag only regex w/o slashes: $STRIP_SLASHES3"
+          # skip branch-ignore if we already know branch-only doesn't match
+          if [[ $BRANCH_MATCH == true ]]; then
+            BRANCH_IGNORE=<<parameters.ignore-branch>>
 
-          if [[ ! "$CIRCLE_TAG" =~ $STRIP_SLASHES3 ]]; then
-            echo "tag doesn't match regex; halting"
+            # check if we got a regex or an exact name
+            if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
+              STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
 
-            TAG_MATCH=false
-            circleci step halt
-          else
-            TAG_MATCH=true
-            echo "tag matches tag-only regex!"
-          fi
-        else # exact name
-          if [[ "$CIRCLE_TAG" != "$TAG_ONLY" ]]; then
-            echo "tag doesn't match exact name; halting"
+              # skip if our branch regex is empty (//)
+              if [ ! -z "$STRIP_SLASHES2" ]; then
+                echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
-            TAG_MATCH=false
-            circleci step halt
-          else
-            TAG_MATCH=true
-            echo "tag matches tag-only exact name!"
-          fi
-        fi
-
-        # skip tag-ignore if we already know tag-only doesn't match
-        if [[ $TAG_MATCH == true ]]; then
-          TAG_IGNORE=<<parameters.ignore-tag>>
-
-          # check if we got "", a regex, or an exact name
-          if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
-            STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
-            echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
-
-            # we will only get into this section if tag-only was set & matched
-            # in which case we don't want to exit, even if default ignore is all tags
-            # skip if tag-ignore value is default (/.*/)
-            # also skip if there is no tag (i.e., we're on a branch)
-
-            if [ ! -z "$CIRCLE_TAG" ]; then
-              if [[ "$TAG_IGNORE" != "/.*/" ]]; then
-                if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
-                  echo "tag matches ignore regex; halting"
+                if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
+                  echo "branch matches ignore regex; halting"
                   circleci step halt
                 fi
               fi
-            fi
-          else  # exact name
-            if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then
-              echo "tag matches exact ignore name; halting"
-              circleci step halt
+            else # exact name
+              if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then
+                echo "branch matches exact ignore name; halting"
+                circleci step halt
+              fi
             fi
           fi
-        fi
+        }
+
+        evaluate_tag_filters () {
+          TAG_ONLY=<<parameters.only-tag>>
+          # check if we got "", a regex, or an exact name
+          if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
+            STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
+            echo "tag only regex w/o slashes: $STRIP_SLASHES3"
+
+            if [[ ! "$CIRCLE_TAG" =~ $STRIP_SLASHES3 ]]; then
+              echo "tag doesn't match regex; halting"
+
+              TAG_MATCH=false
+              circleci step halt
+            else
+              TAG_MATCH=true
+              echo "tag matches tag-only regex!"
+            fi
+          else # exact name
+            if [[ "$CIRCLE_TAG" != "$TAG_ONLY" ]]; then
+              echo "tag doesn't match exact name; halting"
+
+              TAG_MATCH=false
+              circleci step halt
+            else
+              TAG_MATCH=true
+              echo "tag matches tag-only exact name!"
+            fi
+          fi
+
+          # skip tag-ignore if we already know tag-only doesn't match
+          if [[ $TAG_MATCH == true ]]; then
+            TAG_IGNORE=<<parameters.ignore-tag>>
+
+            # check if we got "", a regex, or an exact name
+            if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
+              STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
+              echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
+
+              # we will only get into this section if tag-only was set & matched
+              # in which case we don't want to exit, even if default ignore is all tags
+              # skip if tag-ignore value is default (/.*/)
+              # also skip if there is no tag (i.e., we're on a branch)
+
+              if [ ! -z "$CIRCLE_TAG" ]; then
+                if [[ "$TAG_IGNORE" != "/.*/" ]]; then
+                  if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
+                    echo "tag matches ignore regex; halting"
+                    circleci step halt
+                  fi
+                fi
+              fi
+            else  # exact name
+              if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then
+                echo "tag matches exact ignore name; halting"
+                circleci step halt
+              fi
+            fi
+          fi
+        }
 
   - steps: <<parameters.steps>>

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -1,0 +1,106 @@
+description: >
+  Conditionally run a step, or a series of steps, via paramaterized
+  branch and/or tag filters. Provide either exact branch/tag names or
+  regular expressions. This command *must* be run as the last command in
+  a job (given that you may pass multiple steps to it via the `steps`
+  parameter, however, it is fairly adaptable): if commands or steps are
+  placed after this command within a particular job in your config.yml,
+  they *will not* run. Designed to mirror job-level branch/tag filters:
+  https://circleci.com/docs/2.0/workflows/#using-regular-expressions-to-filter-tags-and-branches
+
+parameters:
+  only-branch:
+    type: string
+    default: /.*/
+    description: >
+      Exact name or regular expression specifying branch(es) to accept.
+      Defaults to a regular expression accepting all branches, following
+      the default execution pattern for job-level branch filtering:
+      https://circleci.com/docs/2.0/workflows/#branch-level-job-execution
+
+  ignore-branch:
+    type: string
+    default: //
+    description: >
+      Exact name or regular expression specifying branch(es) to ignore.
+      Defaults to a regular expression ignoring no branches, following
+      the default execution pattern for job-level branch filtering:
+      https://circleci.com/docs/2.0/workflows/#branch-level-job-execution
+
+  only-tag:
+    type: string
+    default: //
+    description: >
+      Exact name or regular expression specifying tag(s) to accept.
+      Defaults to a regular expression accepting no tags, following
+      the default execution pattern for job-level tag filtering:
+      https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
+
+  ignore-tag:
+    type: string
+    default: /.*/
+    description: >
+      Exact name or regular expression specifying tag(s) to ignore.
+      Defaults to a regular expression ignoring all tags, following
+      the default execution pattern for job-level tag filtering:
+      https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
+
+  steps:
+    type: steps
+    default: []
+    description: >
+      Steps that you'd like to run, if your provided conditions are met
+
+steps:
+  - run:
+      name: evaluate branch/tag filters
+      command: |
+        BRANCH_ONLY="<<parameters.only-branch>>"
+        # check if we got a regex or an exact name
+        if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
+          if [[ ! "$CIRCLE_BRANCH" =~ "$BRANCH_ONLY" ]]; then
+            circleci step halt
+          fi
+        else # exact name
+          if [[ "$CIRCLE_BRANCH" != "$BRANCH_ONLY" ]]; then
+            circleci step halt
+          fi
+        fi
+
+        BRANCH_IGNORE="<<parameters.ignore-branch>>"
+        # check if we got a regex or an exact name
+        if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
+          if [[ "$CIRCLE_BRANCH" =~ "$BRANCH_ONLY" ]]; then
+            circleci step halt
+          fi
+        else # exact name
+          if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then
+            circleci step halt
+          fi
+        fi
+
+        TAG_ONLY="<<parameters.only-tag>>"
+        # check if we got "", a regex, or an exact name
+        if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
+          if [[ ! "$CIRCLE_TAG" =~ "$TAG_ONLY" ]]; then
+            circleci step halt
+          fi
+        else # exact name
+          if [[ "$CIRCLE_TAG" != "$TAG_ONLY" ]]; then
+            circleci step halt
+          fi
+        fi
+
+        TAG_IGNORE="<<parameters.ignore-tag>>"
+        # check if we got "", a regex, or an exact name
+        if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
+          if [[ "$CIRCLE_TAG" =~ "$TAG_ONLY" ]]; then
+            circleci step halt
+          fi
+        else  # exact name
+          if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then
+            circleci step halt
+          fi
+        fi
+
+  - steps: <<parameters.steps>>

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -59,10 +59,12 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
           if [[ ! "$CIRCLE_BRANCH" =~ "$BRANCH_ONLY" ]]; then
+            echo "branch doesn't match regex; halting"
             circleci step halt
           fi
         else # exact name
           if [[ "$CIRCLE_BRANCH" != "$BRANCH_ONLY" ]]; then
+            echo "branch doesn't match exact name; halting"
             circleci step halt
           fi
         fi
@@ -71,10 +73,12 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
           if [[ "$CIRCLE_BRANCH" =~ "$BRANCH_ONLY" ]]; then
+            echo "branch matches ignore regex; halting"
             circleci step halt
           fi
         else # exact name
           if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then
+            echo "branch matches exact ignore name; halting"
             circleci step halt
           fi
         fi
@@ -83,10 +87,12 @@ steps:
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
           if [[ ! "$CIRCLE_TAG" =~ "$TAG_ONLY" ]]; then
+            echo "tag doesn't match regex; halting"
             circleci step halt
           fi
         else # exact name
           if [[ "$CIRCLE_TAG" != "$TAG_ONLY" ]]; then
+            echo "tag doesn't match exact name; halting"
             circleci step halt
           fi
         fi
@@ -95,10 +101,12 @@ steps:
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
           if [[ "$CIRCLE_TAG" =~ "$TAG_ONLY" ]]; then
+            echo "tag matches ignore regex; halting"
             circleci step halt
           fi
         else  # exact name
           if [[ "$CIRCLE_TAG" == "$TAG_IGNORE" ]]; then
+            echo "tag matches exact ignore name; halting"
             circleci step halt
           fi
         fi

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -158,10 +158,12 @@ steps:
             # skip if tag-ignore value is default (/.*/)
             # also skip if there is no tag (i.e., we're on a branch)
 
-            if [ ! -z "$CIRCLE_TAG" || "$TAG_IGNORE" == "/.*/" ]; then
-              if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
-                echo "tag matches ignore regex; halting"
-                circleci step halt
+            if [ ! -z "$CIRCLE_TAG" ]; then
+              if [[ "$TAG_IGNORE" != "/.*/" ]]; then
+                if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
+                  echo "tag matches ignore regex; halting"
+                  circleci step halt
+                fi
               fi
             fi
           else  # exact name

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -1,3 +1,12 @@
+# notes:
+#
+# - actual regex filtering is broken somehow, even though the regexes seem right:
+# https://circleci.com/gh/CircleCI-Public/build-tools-orb/470
+#
+# - may need additional params to specify `true` or `false` for `branches` or `tags`, as CIRCLE_BRANCH seems broken when on a tag, & vice versa (CIRCLE_TAG on a branch):
+# https://circleci.com/gh/CircleCI-Public/build-tools-orb/472
+# https://circleci.com/gh/CircleCI-Public/build-tools-orb/471
+
 description: >
   Conditionally run a step, or a series of steps, via paramaterized
   branch and/or tag filters. Provide either exact branch/tag names or

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -68,7 +68,7 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES1="${BRANCH_ONLY:1:${#BRANCH_ONLY}-2}"
-          echo $STRIP_SLASHES1
+          echo "branch only regex w/o slashes: $STRIP_SLASHES1"
 
           if [[ ! "$CIRCLE_BRANCH" =~ $STRIP_SLASHES1 ]]; then
             echo "branch doesn't match regex; halting"
@@ -85,7 +85,7 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
-          echo $STRIP_SLASHES2
+          echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
           if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
             echo "branch matches ignore regex; halting"
@@ -102,7 +102,7 @@ steps:
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_ONLY:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES3="${TAG_ONLY:1:${#TAG_ONLY}-2}"
-          echo $STRIP_SLASHES3
+          echo "tag only regex w/o slashes: $STRIP_SLASHES3"
 
           if [[ ! "$CIRCLE_TAG" =~ $STRIP_SLASHES3 ]]; then
             echo "tag doesn't match regex; halting"
@@ -119,7 +119,7 @@ steps:
         # check if we got "", a regex, or an exact name
         if [[ "${TAG_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES4="${TAG_IGNORE:1:${#TAG_IGNORE}-2}"
-          echo $STRIP_SLASHES4
+          echo "tag ignore regex w/o slashes: $STRIP_SLASHES4"
 
           if [[ "$CIRCLE_TAG" =~ $STRIP_SLASHES4 ]]; then
             echo "tag matches ignore regex; halting"

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -85,11 +85,15 @@ steps:
         # check if we got a regex or an exact name
         if [[ "${BRANCH_IGNORE:0:1}" = "/" ]]; then # regex
           STRIP_SLASHES2="${BRANCH_IGNORE:1:${#BRANCH_IGNORE}-2}"
-          echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
-          if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
-            echo "branch matches ignore regex; halting"
-            circleci step halt
+          # skip if our regex is empty (//)
+          if [ ! -z "$STRIP_SLASHES2"]; then
+            echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
+
+            if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
+              echo "branch matches ignore regex; halting"
+              circleci step halt
+            fi
           fi
         else # exact name
           if [[ "$CIRCLE_BRANCH" == "$BRANCH_IGNORE" ]]; then

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -64,13 +64,6 @@ steps:
   - run:
       name: evaluate branch/tag filters
       command: |
-        # check if we are in a branch or tag job
-        if [ ! -z "$CIRCLE_BRANCH" ]; then
-          evaluate_branch_filters
-        elif [ ! -z "$CIRCLE_TAG"]; then
-          evaluate_tag_filters
-        fi
-
         evaluate_branch_filters () {
           BRANCH_ONLY=<<parameters.only-branch>>
 
@@ -184,5 +177,12 @@ steps:
             fi
           fi
         }
+
+        # check if we are in a branch or tag job
+        if [ ! -z "$CIRCLE_BRANCH" ]; then
+          evaluate_branch_filters
+        elif [ ! -z "$CIRCLE_TAG" ]; then
+          evaluate_tag_filters
+        fi
 
   - steps: <<parameters.steps>>

--- a/src/commands/run-filtered.yml
+++ b/src/commands/run-filtered.yml
@@ -79,6 +79,9 @@ steps:
               circleci step halt
             else
               BRANCH_MATCH=true
+              if [[ "$BRANCH_ONLY" != "/.*/" ]]; then
+                BRANCH_ONLY_SET=true
+              fi
               echo "branch matches branch-only regex!"
             fi
           else # exact name
@@ -106,8 +109,10 @@ steps:
                 echo "branch ignore regex w/o slashes: $STRIP_SLASHES2"
 
                 if [[ "$CIRCLE_BRANCH" =~ $STRIP_SLASHES2 ]]; then
-                  echo "branch matches ignore regex; halting"
-                  circleci step halt
+                  if [[ "$BRANCH_ONLY_SET" != true ]]; then
+                    echo "branch matches ignore regex; halting"
+                    circleci step halt
+                  fi
                 fi
               fi
             else # exact name

--- a/src/executors/ci-base.yml
+++ b/src/executors/ci-base.yml
@@ -1,0 +1,3 @@
+resource_class: small
+docker:
+  - image: cibuilds/base

--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -1,0 +1,10 @@
+parameters:
+  xcode-version:
+    type: string
+    default: "10.1.0"
+    description: >
+      Version of Xcode to use. See the following for full list of options:
+      https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
+
+macos:
+  xcode: <<parameters.xcode-version>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

would be cool if folks could apply branch/tag filters to commands/steps or sets of commands/steps, just as they can do so with jobs in workflows

### Description

add a command allowing people to essentially apply branch/tag filters to a command/step or set of commands/steps
