### PR TITLE
Ci tools command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ workflows:
             #       git tag -d $(git tag -l)
 
             - run:
-                name: cleanup filtered-run-tests branches, if they exist
+                name: cleanup filtered-run-tests branches/tags, if they exist
                 command: |
                   git branch -d filtered-run-tests_only-branch-dev || true
                   git push origin --delete filtered-run-tests_only-branch-dev || true
@@ -172,6 +172,16 @@ workflows:
 
                   git branch -d filtered-run-tests_ignore-branch-master || true
                   git push origin --delete filtered-run-tests_ignore-branch-master || true
+
+                  git tag -d filtered-run-tests_only-tag-dev || true
+                  git tag -d filtered-run-tests_only-tag-master || true
+                  git push origin --delete filtered-run-tests_only-tag-dev || true
+                  git push origin --delete filtered-run-tests_only-tag-master || true
+
+                  git tag -d filtered-run-tests_ignore-tag-dev || true
+                  git tag -d filtered-run-tests_ignore-tag-master || true
+                  git push origin --delete filtered-run-tests_ignore-tag-dev || true
+                  git push origin --delete filtered-run-tests_ignore-tag-master || true
 
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  orb-tools: circleci/orb-tools@8.3.0
+  jq: circleci/jq-orb@1.8.0
+  orb-tools: circleci/orb-tools@8.13.0
 
 commands:
   filtered-run-tests_only-branch:
@@ -48,6 +49,18 @@ jobs:
     executor: build-tools/ci-base
     steps:
       - checkout
+
+  test-ci-tools:
+    parameters:
+      executor:
+        type: executor
+
+    executor: <<parameters.executor>>
+
+    steps:
+      - jq/install
+
+      - build-tools/install-ci-tools
 
   test-orb-commands:
     executor: build-tools/macos
@@ -103,7 +116,14 @@ integration-master_filters: &integration-master_filters
     only: /master-.*/
 
 prod-deploy_requires: &prod-deploy_requires
-  [test-orb-commands-master, introspect-orbs-master, filtered-run-tests_only-branch-master, filtered-run-tests_ignore-branch-master, filtered-run-tests_only-tag-master, filtered-run-tests_ignore-tag-master]
+  [
+    test-orb-commands-master,
+    introspect-orbs-master,
+    filtered-run-tests_only-branch-master,
+    filtered-run-tests_ignore-branch-master,
+    filtered-run-tests_only-tag-master,
+    filtered-run-tests_ignore-tag-master
+  ]
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -242,6 +262,28 @@ workflows:
           name: introspect-orbs-dev
           filters: *integration-dev_filters
 
+      # ci-tools tests
+      - test-ci-tools:
+          name: ci-tools-alpine-dev
+          executor: orb-tools/alpine
+          filters: *integration-dev_filters
+
+      - test-ci-tools:
+          name: ci-tools-docker-dev
+          executor: orb-tools/node
+          filters: *integration-dev_filters
+
+      - test-ci-tools:
+          name: ci-tools-mac-dev
+          executor: orb-tools/macos
+          filters: *integration-dev_filters
+
+      - test-ci-tools:
+          name: ci-tools-machine-dev
+          executor: orb-tools/machine
+          filters: *integration-dev_filters
+
+      # filtered-run tests
       - filtered-run-tests:
           name: filtered-run-tests_only-branch-dev
           filters:
@@ -287,6 +329,7 @@ workflows:
           name: introspect-orbs-master
           filters: *integration-master_filters
 
+      # filtered-run tests
       - filtered-run-tests:
           name: filtered-run-tests_only-branch-master
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  jq: circleci/jq-orb@1.8.0
   orb-tools: circleci/orb-tools@8.13.0
 
 commands:
@@ -58,8 +57,6 @@ jobs:
     executor: <<parameters.executor>>
 
     steps:
-      - jq/install
-
       - build-tools/install-ci-tools
 
   test-orb-commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,11 @@ prod-deploy_requires: &prod-deploy_requires
     filtered-run-tests_only-branch-master,
     filtered-run-tests_ignore-branch-master,
     filtered-run-tests_only-tag-master,
-    filtered-run-tests_ignore-tag-master
+    filtered-run-tests_ignore-tag-master,
+    ci-tools-alpine-master,
+    ci-tools-docker-master,
+    ci-tools-mac-master,
+    ci-tools-machine-master
   ]
 
 workflows:
@@ -334,6 +338,27 @@ workflows:
 
       - build-tools/introspect-orbs:
           name: introspect-orbs-master
+          filters: *integration-master_filters
+
+      # ci-tools tests
+      - test-ci-tools:
+          name: ci-tools-alpine-master
+          executor: orb-tools/alpine
+          filters: *integration-master_filters
+
+      - test-ci-tools:
+          name: ci-tools-docker-master
+          executor: orb-tools/node
+          filters: *integration-master_filters
+
+      - test-ci-tools:
+          name: ci-tools-mac-master
+          executor: orb-tools/macos
+          filters: *integration-master_filters
+
+      - test-ci-tools:
+          name: ci-tools-machine-master
+          executor: orb-tools/machine
           filters: *integration-master_filters
 
       # filtered-run tests

--- a/src/commands/install-ci-tools.yml
+++ b/src/commands/install-ci-tools.yml
@@ -1,0 +1,110 @@
+description: >
+  Install packages commonly required in CircleCI jobs; designed to
+  replicate the tooling pre-loaded in CircleCI's Docker convenience
+  images: https://github.com/circleci/circleci-images/blob/master/shared/images/Dockerfile-basic.template#L26
+
+steps:
+  - run:
+      name: Install CI tools
+      command: |
+        if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
+        # determine OS
+        if uname -a | grep Darwin > /dev/null 2>&1; then
+          PLATFORM=mac
+        elif cat /etc/issue | grep Alpine > /dev/null 2>&1; then
+          PLATFORM=alpine
+        elif cat /etc/issue | grep Debian > /dev/null 2>&1; then
+          PLATFORM=debian
+        elif cat /etc/issue | grep Ubuntu > /dev/null 2>&1; then
+          PLTAFORM=ubuntu
+        fi
+
+        case $PLATFORM in
+        mac)
+          # brew install formulas
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+            bzip2 \
+            coreutils \
+            curl \
+            git \
+            gzip \
+            gnu-tar \
+            gnupg \
+            mercurial \
+            netcat \
+            openssh \
+            parallel \
+            unzip \
+            wget \
+            zip \
+            > /dev/null
+        ;;
+        alpine)
+          # apk add pkgs
+          apk add \
+            bzip2 \
+            ca-certificates \
+            curl \
+            git \
+            gnupg \
+            gzip \
+            mercurial \
+            net-tools \
+            netcat-openbsd \
+            openssh-client \
+            parallel \
+            tar \
+            unzip \
+            wget \
+            zip \
+            > /dev/null
+        ;;
+        debian)
+          # apt-get install packages
+          $SUDO apt-get update > /dev/null && \
+            $SUDO apt-get install -y \
+            bzip2 \
+            ca-certificates \
+            curl \
+            git \
+            gnupg \
+            gzip \
+            locales \
+            mercurial \
+            net-tools \
+            netcat \
+            openssh-client \
+            parallel \
+            tar \
+            unzip \
+            wget \
+            zip \
+            > /dev/null
+        ;;
+        ubuntu)
+          # apt-get install packages
+          $SUDO apt-get update > /dev/null && \
+            $SUDO apt-get install -y \
+            bzip2 \
+            ca-certificates \
+            curl \
+            git \
+            gnupg \
+            gzip \
+            locales \
+            mercurial \
+            net-tools \
+            netcat \
+            openssh-client \
+            parallel \
+            tar \
+            unzip \
+            wget \
+            zip \
+            > /dev/null
+        ;;
+        *)
+          echo "Sorry, you are using an unsupported OS/distribution (orb command is currently compatible across macOS, Alpine Linux, Debian Linux, and Ubuntu Linux)"
+        ;;
+        esac

--- a/src/commands/install-ci-tools.yml
+++ b/src/commands/install-ci-tools.yml
@@ -43,6 +43,8 @@ steps:
             wget \
             zip \
             > /dev/null 2>&1
+
+          echo "CI tools were installed successfully"
         ;;
         alpine)
           # apk add pkgs
@@ -61,8 +63,10 @@ steps:
             tar \
             unzip \
             wget \
-            zip #\
-            #> /dev/null
+            zip \
+            > /dev/null 2>&1
+
+            echo "CI tools were installed successfully"
         ;;
         debian)
           # apt-get install packages
@@ -85,6 +89,8 @@ steps:
             wget \
             zip \
             > /dev/null 2>&1
+
+            echo "CI tools were installed successfully"
         ;;
         ubuntu)
           # apt-get install packages
@@ -105,8 +111,10 @@ steps:
             tar \
             unzip \
             wget \
-            zip #\
-            #> /dev/null
+            zip \
+            > /dev/null 2>&1
+
+            echo "CI tools were installed successfully"
         ;;
         *)
           echo "Sorry, you are using an unsupported OS/distribution (orb command is currently compatible across macOS, Alpine Linux, Debian Linux, and Ubuntu Linux)"

--- a/src/commands/install-ci-tools.yml
+++ b/src/commands/install-ci-tools.yml
@@ -12,12 +12,16 @@ steps:
         # determine OS
         if uname -a | grep Darwin > /dev/null 2>&1; then
           PLATFORM=mac
+          echo "macOS detected; Homebrew will be used"
         elif cat /etc/issue | grep Alpine > /dev/null 2>&1; then
           PLATFORM=alpine
+          echo "Alpine Linux detected; apk will be used"
         elif cat /etc/issue | grep Debian > /dev/null 2>&1; then
           PLATFORM=debian
+          echo "Debian Linux detected; apt-get will be used"
         elif cat /etc/issue | grep Ubuntu > /dev/null 2>&1; then
-          PLTAFORM=ubuntu
+          PLATFORM=ubuntu
+          echo "Ubuntu Linux detected; apt-get will be used"
         fi
 
         case $PLATFORM in
@@ -38,7 +42,7 @@ steps:
             unzip \
             wget \
             zip \
-            > /dev/null
+            > /dev/null 2>&1
         ;;
         alpine)
           # apk add pkgs
@@ -57,8 +61,8 @@ steps:
             tar \
             unzip \
             wget \
-            zip \
-            > /dev/null
+            zip #\
+            #> /dev/null
         ;;
         debian)
           # apt-get install packages
@@ -80,7 +84,7 @@ steps:
             unzip \
             wget \
             zip \
-            > /dev/null
+            > /dev/null 2>&1
         ;;
         ubuntu)
           # apt-get install packages
@@ -101,8 +105,8 @@ steps:
             tar \
             unzip \
             wget \
-            zip \
-            > /dev/null
+            zip #\
+            #> /dev/null
         ;;
         *)
           echo "Sorry, you are using an unsupported OS/distribution (orb command is currently compatible across macOS, Alpine Linux, Debian Linux, and Ubuntu Linux)"

--- a/src/examples/ci-tools.yml
+++ b/src/examples/ci-tools.yml
@@ -1,0 +1,32 @@
+description: >
+  Use a third-party Docker image and layer on CircleCI's convenience
+  image tooling at job runtime
+
+usage:
+  version: 2.1
+
+  orbs:
+    browser-tools: circleci/browser-tools@x.y.z
+    build-tools: circleci/build-tools@x.y.z
+    docker: circleci/docker@x.y.z
+    jq: circleci/jq@x.y.z
+
+  jobs:
+    your-job:
+      docker:
+        - image: your-third/party-image:image-tag
+      steps:
+        - checkout
+
+        - build-tools/install-ci-tools
+
+        - jq/install
+
+        - docker/install-docker-tools
+
+        - browser-tools/install-browser-tools
+
+  workflows:
+    your-workflow:
+      jobs:
+        - your-job


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

allow folks to replicate the environment provided by our convenience images, using any docker image, by layering on the same tooling at runtime

### Description

`install-ci-tools` command installs common packages available in both our [old base image](https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template) and [new prototype base image](https://github.com/CircleCI-Public/cimg-base/blob/master/ubuntu/Dockerfile)—& it works across mac / ubuntu / debian / alpine envs
