### PR TITLE
Ci tools support oracle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,6 @@ jobs:
     steps:
       - build-tools/install-ci-tools
 
-      - build-tools/ensure-command:
-          command: make
-
   test-orb-commands:
     executor: build-tools/macos
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,10 @@ orbs:
 
 executors:
   oracle:
-    docker: [image: openjdk:12-oracle]
     resource_class: small
+    docker:
+      - image: openjdk:12-oracle
+
 
 commands:
   filtered-run-tests_only-branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,8 @@ prod-deploy_requires: &prod-deploy_requires
     ci-tools-alpine-master,
     ci-tools-docker-master,
     ci-tools-mac-master,
-    ci-tools-machine-master
+    ci-tools-machine-master,
+    ci-tools-oracle-master
   ]
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,8 @@ jobs:
     executor: <<parameters.executor>>
 
     steps:
-      - run:
-          name: see if make is installed
-          command: which make
+      - build-tools/ensure-command:
+          command: make
 
       - build-tools/install-ci-tools
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   build-tools: circleci/build-tools@dev:alpha
-  orb-tools: circleci/orb-tools@8.13.0
+  orb-tools: circleci/orb-tools@8.20.0
 
 executors:
   oracle:
@@ -64,10 +64,10 @@ jobs:
     executor: <<parameters.executor>>
 
     steps:
+      - build-tools/install-ci-tools
+
       - build-tools/ensure-command:
           command: make
-
-      - build-tools/install-ci-tools
 
   test-orb-commands:
     executor: build-tools/macos
@@ -421,6 +421,7 @@ workflows:
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:
           name: dev-promote-patch
+          ssh-fingerprints: 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
           context: orb-publishing
           orb-name: circleci/build-tools
           requires: *prod-deploy_requires
@@ -433,6 +434,7 @@ workflows:
       - orb-tools/dev-promote-prod:
           name: dev-promote-minor
           release: minor
+          ssh-fingerprints: 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
           context: orb-publishing
           orb-name: circleci/build-tools
           requires: *prod-deploy_requires
@@ -444,6 +446,7 @@ workflows:
 
       - orb-tools/dev-promote-prod:
           name: dev-promote-major
+          ssh-fingerprints: 16:68:60:ae:33:5c:4e:b3:be:61:26:ce:9a:f3:ed:84
           release: major
           context: orb-publishing
           orb-name: circleci/build-tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ orbs:
   build-tools: circleci/build-tools@dev:alpha
   orb-tools: circleci/orb-tools@8.13.0
 
+executors:
+  oracle:
+    docker: [image: openjdk:12-oracle]
+    resource_class: small
+
 commands:
   filtered-run-tests_only-branch:
     steps:
@@ -57,6 +62,10 @@ jobs:
     executor: <<parameters.executor>>
 
     steps:
+      - run:
+          name: see if make is installed
+          command: which make
+
       - build-tools/install-ci-tools
 
   test-orb-commands:
@@ -294,6 +303,11 @@ workflows:
           executor: orb-tools/machine
           filters: *integration-dev_filters
 
+      - test-ci-tools:
+          name: ci-tools-oracle-dev
+          executor: oracle
+          filters: *integration-dev_filters
+
       # filtered-run tests
       - filtered-run-tests:
           name: filtered-run-tests_only-branch-dev
@@ -359,6 +373,11 @@ workflows:
       - test-ci-tools:
           name: ci-tools-machine-master
           executor: orb-tools/machine
+          filters: *integration-master_filters
+
+      - test-ci-tools:
+          name: ci-tools-oracle-master
+          executor: oracle
           filters: *integration-master_filters
 
       # filtered-run tests

--- a/src/commands/install-ci-tools.yml
+++ b/src/commands/install-ci-tools.yml
@@ -36,6 +36,7 @@ steps:
             gnu-tar \
             gnupg \
             mercurial \
+            make \
             netcat \
             openssh \
             parallel \
@@ -55,6 +56,7 @@ steps:
             git \
             gnupg \
             gzip \
+            make \
             mercurial \
             net-tools \
             netcat-openbsd \
@@ -80,6 +82,7 @@ steps:
             gzip \
             locales \
             mercurial \
+            make \
             net-tools \
             netcat \
             openssh-client \
@@ -104,6 +107,7 @@ steps:
             gzip \
             locales \
             mercurial \
+            make \
             net-tools \
             netcat \
             openssh-client \
@@ -117,7 +121,7 @@ steps:
             echo "CI tools were installed successfully"
         ;;
         *)
-          # check for Oracle Linux or other distros using yum
+          # check for/try with Oracle Linux or other distros using yum
           if command -v yum >> /dev/null 2>&1; then
             $SUDO yum install -y \
               bzip2 \
@@ -126,6 +130,7 @@ steps:
               git \
               gnupg \
               gzip \
+              make \
               mercurial \
               net-tools \
               nc \

--- a/src/commands/install-ci-tools.yml
+++ b/src/commands/install-ci-tools.yml
@@ -117,6 +117,33 @@ steps:
             echo "CI tools were installed successfully"
         ;;
         *)
-          echo "Sorry, you are using an unsupported OS/distribution (orb command is currently compatible across macOS, Alpine Linux, Debian Linux, and Ubuntu Linux)"
+          # check for Oracle Linux or other distros using yum
+          if command -v yum >> /dev/null 2>&1; then
+            $SUDO yum install -y \
+              bzip2 \
+              ca-certificates \
+              curl \
+              git \
+              gnupg \
+              gzip \
+              mercurial \
+              net-tools \
+              nc \
+              openssh-clients \
+              parallel \
+              tar \
+              unzip \
+              wget \
+              zip \
+              > /dev/null 2>&1
+
+              # locales
+              yum reinstall -y \
+              glibc-common \
+              > /dev/null 2>&1
+          else
+            echo "Sorry, you are using an unsupported OS/distribution (orb command is currently compatible across macOS, Alpine Linux, Debian Linux, and Ubuntu Linux)"
+            exit 1
+          fi
         ;;
         esac


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

- the `install-ci-tools` command was specifically created to address an issue where the upstream maintainers of the docker library openjdk image moved its underlying linux distribution from ubuntu to oracle linux for all openjdk12-based tags
- however, this command was never made to work with oracle linux, which kind of defeats the purposes: https://discuss.circleci.com/t/convenience-images-update-add-our-convenience-image-tooling-to-your-own-docker-images-with-orbs

### Description

- add option to automatically detect presence of `yum` & install the same tools that way if possible
- also install `make` by default


### Next steps

- making _all_ our first-party orbs support oracle linux / yum is probably more trouble than it's worth
- however, it _could_ be good to round out the suite of orb commands designed specifically to replicate the experience of using circleci convenience images (`node/install`, `docker/install-docker-tools`, `browser-tools/install-browsers`, `jq/install`, primarily) with oracle linux support
- since most of these commands were intentionally designed not to rely on package managers, this may not end up being much work at all, as, besides from lacking `apt-get` & some other basic tooling (which this PR should help address), the openjdk oracle linux-based docker images seem to be basically lightly skinned versions of ubuntu (e.g., `uname -a` reports `ubuntu`)