### PR TITLE
Bug fix: all env-info writes replace their log files entirely

### DIFF
--- a/src/commands/env-info.yml
+++ b/src/commands/env-info.yml
@@ -22,17 +22,17 @@ steps:
         echo "Output will be stored in: <<parameters.data-dir>> (creating it if it does not exist...)"
         echo "----------------------------------------------------------------------------------------------------"
         mkdir -p <<parameters.data-dir>>
-        echo "System information:" > <<parameters.data-dir>>/uname_arch.log
-        echo "uname -a:" $(uname -a) > <<parameters.data-dir>>/uname_arch.log
-        echo "arch: " $(arch) > <<parameters.data-dir>>/uname_arch.log
-        echo "Build information:" > <<parameters.data-dir>>/build_info.log
-        echo "TRIGGERER: ${CIRCLE_USERNAME}" > <<parameters.data-dir>>/build_info.log
-        echo "BUILD_NUMBER: ${CIRCLE_BUILD_NUM}" > <<parameters.data-dir>>/build_info.log
-        echo "BUILD_URL: ${CIRCLE_BUILD_URL}" > <<parameters.data-dir>>/build_info.log
-        echo "BRANCH: ${CIRCLE_BRANCH}" > <<parameters.data-dir>>/build_info.log
-        echo "RUNNING JOB: ${CIRCLE_JOB}" > <<parameters.data-dir>>/build_info.log
-        echo "JOB PARALLELISM: ${CIRCLE_NODE_TOTAL}" > <<parameters.data-dir>>/build_info.log
-        echo "CIRCLE_REPOSITORY_URL: ${CIRCLE_REPOSITORY_URL}" > <<parameters.data-dir>>/build_info.log
+        echo "System information:" >> <<parameters.data-dir>>/uname_arch.log
+        echo "uname -a:" $(uname -a) >> <<parameters.data-dir>>/uname_arch.log
+        echo "arch: " $(arch) >> <<parameters.data-dir>>/uname_arch.log
+        echo "Build information:" >> <<parameters.data-dir>>/build_info.log
+        echo "TRIGGERER: ${CIRCLE_USERNAME}" >> <<parameters.data-dir>>/build_info.log
+        echo "BUILD_NUMBER: ${CIRCLE_BUILD_NUM}" >> <<parameters.data-dir>>/build_info.log
+        echo "BUILD_URL: ${CIRCLE_BUILD_URL}" >> <<parameters.data-dir>>/build_info.log
+        echo "BRANCH: ${CIRCLE_BRANCH}" >> <<parameters.data-dir>>/build_info.log
+        echo "RUNNING JOB: ${CIRCLE_JOB}" >> <<parameters.data-dir>>/build_info.log
+        echo "JOB PARALLELISM: ${CIRCLE_NODE_TOTAL}" >> <<parameters.data-dir>>/build_info.log
+        echo "CIRCLE_REPOSITORY_URL: ${CIRCLE_REPOSITORY_URL}" >> <<parameters.data-dir>>/build_info.log
         cat /proc/cpuinfo > <<parameters.data-dir>>/proc_cpuinfo.log || true
         dpkg -l > <<parameters.data-dir>>/dpkg.log || true
         yarn list > <<parameters.data-dir>>/yarn.log || true

--- a/src/commands/env-info.yml
+++ b/src/commands/env-info.yml
@@ -22,10 +22,10 @@ steps:
         echo "Output will be stored in: <<parameters.data-dir>> (creating it if it does not exist...)"
         echo "----------------------------------------------------------------------------------------------------"
         mkdir -p <<parameters.data-dir>>
-        echo "System information:" >> <<parameters.data-dir>>/uname_arch.log
+        echo "System information:" > <<parameters.data-dir>>/uname_arch.log
         echo "uname -a:" $(uname -a) >> <<parameters.data-dir>>/uname_arch.log
         echo "arch: " $(arch) >> <<parameters.data-dir>>/uname_arch.log
-        echo "Build information:" >> <<parameters.data-dir>>/build_info.log
+        echo "Build information:" > <<parameters.data-dir>>/build_info.log
         echo "TRIGGERER: ${CIRCLE_USERNAME}" >> <<parameters.data-dir>>/build_info.log
         echo "BUILD_NUMBER: ${CIRCLE_BUILD_NUM}" >> <<parameters.data-dir>>/build_info.log
         echo "BUILD_URL: ${CIRCLE_BUILD_URL}" >> <<parameters.data-dir>>/build_info.log


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary
(n/a)
### Motivation, issues

I noticed when using the `env-info` command that the logs weren't actually accumulating data as intended. Rather, each write ended up replacing the previously written data from the same command execution.

for example, the `build_info.log` file should have 8 lines worth of content, but I was only getting 1 (the last one, `CIRCLE_REPOSITORY_URL`).

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
This PR fixes the log writes so that the first write to each log creates/replaces anything there previously, while the ensuing writes are appended to their respective files.
