### PR TITLE
Update to use recommended issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,12 @@
+---
+name: Bug
+about: Use this template when reporting an issue with this orb
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 ### Orb version
 
 <!---


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions - Not Required
- [x] Examples have been added for any significant new features - Not Required
- [x] README has been updated, if necessary - Not Required

### Motivation, issues

When viewing the current issue template on GitHub, you are presented with this information:

![image](https://user-images.githubusercontent.com/1271146/65993398-1544e580-e489-11e9-9a21-372b558d330d.png)

The documentation for this GitHub feature can be found here:

https://help.github.com/en/articles/about-issue-and-pull-request-templates

On reading that article, the recommendation is to switch to the new issue template format:

> It is possible to manually create a single issue template in Markdown using the legacy issue template workflow, and project contributors will automatically see the template's contents in the issue body. However, we recommend using the upgraded multiple issue template builder to create issue templates.

### Description

Remove the existing ISSUE_TEMPLATE.md file, and replace it with a new bug.md file in the ISSUE_TEMPLATE folder.

This opens up the potential for creating multiple issue templates, for example, one specifically for requesting a new feature, reporting a security finding, etc.

### Related Pull Requests

I have opened similar PR's in other Orb Repositories:

https://github.com/CircleCI-Public/twilio-orb/pull/3
https://github.com/CircleCI-Public/slack-orb/pull/88
https://github.com/CircleCI-Public/docker-orb/pull/23
https://github.com/CircleCI-Public/circleci-cli-orb/pull/2
https://github.com/CircleCI-Public/azure-cli-orb/pull/4
https://github.com/CircleCI-Public/artifactory-orb/pull/17