### PR TITLE
Include iOS simulator crash logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ build-tools/env-info
 ```
 
 ### [`build-tools/ios-logs`](https://circleci.com/orbs/registry/orb/circleci/build-tools#commands-ios-logs)
-Save Fastlane and Xcode information from an iOS job, to be stored as artifacts and inspected later.
+Save Fastlane logs, Xcode information and iOS simulator crash reports from an iOS job, to be stored as artifacts and inspected later
 
 ```yaml
 build-tools/ios-logs

--- a/src/commands/ios-logs.yml
+++ b/src/commands/ios-logs.yml
@@ -1,5 +1,5 @@
 description: >
-  Save Fastlane and Xcode information from an iOS job, to be stored as artifacts and inspected later
+  Save Fastlane logs, Xcode information and iOS simulator crash reports from an iOS job, to be stored as artifacts and inspected later
 
 parameters:
   data-dir:
@@ -24,5 +24,6 @@ steps:
         echo export FL_OUTPUT_DIR=~/.ccidiag/ios-logs >> $BASH_ENV
         cp -R ~/project/fastlane ~/.ccidiag/ios-logs
         cp ~/project/*.xcodeproj/project.pbxproj ~/.ccidiag/ios-logs
+        cp -R ~/Library/Logs/DiagnosticReports ~/.ccidiag/ios-logs
         echo "----------------------------------------------------------------------------------------------------"
         echo "iOS diagnostic data has been stored in <<parameters.data-dir>>"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Include iOS simulator crash logs for macOS jobs

### Description

Added `~/Library/Logs/DiagnosticReports` to the iOS log collection
