### PR TITLE
[semver:patch] Replace the name diagnostic-orb with build-tools

### DIFF
--- a/src/examples/debug-ios-job.yml
+++ b/src/examples/debug-ios-job.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    build-tools: circleci/build-tools@1.0.0
+    build-tools: circleci/build-tools@2.6.3
 
   executors:
     macos:

--- a/src/examples/debug-ios-job.yml
+++ b/src/examples/debug-ios-job.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    build-tools: circleci/build-tools@2.6.3
+    build-tools: circleci/build-tools@x.y.z
 
   executors:
     macos:

--- a/src/examples/debug-ios-job.yml
+++ b/src/examples/debug-ios-job.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    diagnostic-orb: circleci/diagnostic-orb@1.0.0
+    build-tools: circleci/build-tools@1.0.0
 
   executors:
     macos:
@@ -30,8 +30,8 @@ usage:
       jobs:
         - build:
             post-steps:
-              - diagnostic-orb/ios-logs
-              - diagnostic-orb/store-report
+              - build-tools/ios-logs
+              - build-tools/store-report
 
         - deploy:
             requires:

--- a/src/examples/full-diagnostic.yml
+++ b/src/examples/full-diagnostic.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    build-tools: circleci/build-tools@2.6.3
+    build-tools: circleci/build-tools@x.y.z
 
   # this example uses the machine executor; these orb commands
   # should work in any Debian- or Ubuntu-based environment

--- a/src/examples/full-diagnostic.yml
+++ b/src/examples/full-diagnostic.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    build-tools: circleci/build-tools@1.0.0
+    build-tools: circleci/build-tools@2.6.3
 
   # this example uses the machine executor; these orb commands
   # should work in any Debian- or Ubuntu-based environment

--- a/src/examples/full-diagnostic.yml
+++ b/src/examples/full-diagnostic.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    diagnostic-orb: circleci/diagnostic-orb@1.0.0
+    build-tools: circleci/build-tools@1.0.0
 
   # this example uses the machine executor; these orb commands
   # should work in any Debian- or Ubuntu-based environment
@@ -31,11 +31,11 @@ usage:
       jobs:
         - build:
             pre-steps:
-              - diagnostic-orb/env-info
-              - diagnostic-orb/memory
-              - diagnostic-orb/test-results
+              - build-tools/env-info
+              - build-tools/memory
+              - build-tools/test-results
             post-steps:
-              - diagnostic-orb/store-report
+              - build-tools/store-report
 
         - deploy:
             requires:

--- a/src/examples/node-debug-custom-param.yml
+++ b/src/examples/node-debug-custom-param.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    diagnostic-orb: circleci/diagnostic-orb@1.0.0
+    build-tools: circleci/build-tools@1.0.0
 
   executors:
     node:
@@ -31,14 +31,14 @@ usage:
       jobs:
         - build:
             post-steps:
-              - diagnostic-orb/env-info:
+              - build-tools/env-info:
                   data-dir: diagnostic-report/env-info
 
               # data-dir can be any directory; however, it's important to make sure that
               # directories passed as parameters to any debugging commands are
               # subdirectories of the directory passed to the final store-report command
 
-              - diagnostic-orb/store-report:
+              - build-tools/store-report:
                   data-dir: diagnostic-report
 
         - deploy:

--- a/src/examples/node-debug-custom-param.yml
+++ b/src/examples/node-debug-custom-param.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    build-tools: circleci/build-tools@1.0.0
+    build-tools: circleci/build-tools@2.6.3
 
   executors:
     node:

--- a/src/examples/node-debug-custom-param.yml
+++ b/src/examples/node-debug-custom-param.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    build-tools: circleci/build-tools@2.6.3
+    build-tools: circleci/build-tools@x.y.z
 
   executors:
     node:


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
  why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

I was trying to use this orb but the example on the website (https://circleci.com/orbs/registry/orb/circleci/build-tools#usage-debug-ios-job) and in this repo (https://github.com/CircleCI-Public/build-tools-orb/tree/master/src/examples) is using the wrong orb name. From https://github.com/CircleCI-Public/build-tools-orb/issues/6, I'd assume this is the remaining of the old name. That's why I want to get rid of them so no one else would get confused like me.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
- Replaced `diagnostic-orb` with `build-tools`
- Replace the orb version in the example from `1.0.0` to the current version, `2.6.3`.