### PR TITLE
[semver:minor] Fix merge with parent

### DIFF
--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -35,7 +35,7 @@ steps:
                 echo "Can't merge branch into itself! Skipping."
                 exit 0
               fi
-              git checkout <<parameters.parent>>
+              git checkout -f -B parent <<parameters.parent>>
               git merge --no-ff --no-commit $CHILD_BRANCH
   - when:
       condition:
@@ -50,5 +50,5 @@ steps:
                 echo "Can't merge branch into itself! Skipping."
                 exit 0
               fi
-              git checkout $PARENT_BRANCH
+              git checkout -f -B parent $PARENT_BRANCH
               git merge --no-ff --no-commit $CHILD_BRANCH

--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -12,6 +12,18 @@ parameters:
     default: ""
 
 steps:
+  - run:
+      name: Set Git identity
+      command: |
+        USER_EMAIL=$(git config --get user.email)
+        USER_NAME=$(git config --get user.name)
+
+        if [ "$USER_EMAIL" = "" ]; then
+          git config user.email "circleci@example.com"
+        fi
+        if [ "$USER_NAME" = "" ]; then
+          git config user.name "CircleCI"
+        fi
   - when:
       condition: <<parameters.parent>>
       steps:

--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -36,7 +36,7 @@ steps:
                 exit 0
               fi
               git checkout <<parameters.parent>>
-              git merge $CHILD_BRANCH
+              git merge --no-ff --no-commit $CHILD_BRANCH
   - when:
       condition:
         not: <<parameters.parent>>
@@ -51,4 +51,4 @@ steps:
                 exit 0
               fi
               git checkout $PARENT_BRANCH
-              git merge $CHILD_BRANCH
+              git merge --no-ff --no-commit $CHILD_BRANCH

--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -5,11 +5,28 @@ description: >
 parameters:
   parent:
     type: string
+    default: ""
     description: >
       Strictly set a parent (e.g "main") that the branch being tested should
       always be merged in to. The parent branch will attempt to be discovered
       if this is blank.
+  no_commit:
+    type: boolean
+    default: false
+    description: >
+      Don't commit the merged state. Can see the changes with `git diff`.
+  no_fast_forward:
+    type: boolean
+    default: false
+    description: >
+      Do not allow merge by fast-forwarding the commits. Forces the changes to be staged
+      for a commit.
+  named_detatched_parent:
+    type: string
     default: ""
+    description: >
+      Name used for a branch created on checkout when a detached HEAD state is expected.
+      This way the merge target has a name you can reference.
 
 steps:
   - run:
@@ -35,8 +52,8 @@ steps:
                 echo "Can't merge branch into itself! Skipping."
                 exit 0
               fi
-              git checkout -f -B parent <<parameters.parent>>
-              git merge --no-ff --no-commit $CHILD_BRANCH
+              git checkout<<# parameters.named_detatched_parent >> -f -B << parameters.named_detatched_parent >><</ parameters.named_detatched_parent >> <<parameters.parent>>
+              git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> $CHILD_BRANCH
   - when:
       condition:
         not: <<parameters.parent>>
@@ -50,5 +67,5 @@ steps:
                 echo "Can't merge branch into itself! Skipping."
                 exit 0
               fi
-              git checkout -f -B parent $PARENT_BRANCH
-              git merge --no-ff --no-commit $CHILD_BRANCH
+              git checkout<<# parameters.named_detatched_parent >> -f -B << parameters.named_detatched_parent >><</ parameters.named_detatched_parent >> $PARENT_BRANCH
+              git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> $CHILD_BRANCH


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
  why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The changes in this PR address the following issues:

- `merge-with-parent` failing with `fatal: unable to auto-detect email address (got 'root@4f4eea8052cd.(none)')` error
- `merge-with-parent` failing with `error: Terminal is dumb, but EDITOR unset` error
- `merge-with-parent` leaving the checkout in a `detached HEAD` state when `parent` is set to a non-local branch (i.e. `origin/master`)

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Changes made to `merge-with-parent` command:
- Set a reasonable default for `user.email` and/or `user.name`, if none are detected
- (Optional) Don't commit the results of the merge (`--no-commit` flag)
- (Optional) Make the "merge" operation predictable by avoiding "fast-forward" operation (`--no-ff` flag)
- (Optional) Create a local branch when checking out a non-local parent