### PR TITLE
[semver:minor] Fix merge-with-parent, part 2

### DIFF
--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -21,7 +21,7 @@ parameters:
     description: >
       Do not allow merge by fast-forwarding the commits. Forces the changes to be staged
       for a commit.
-  named_detatched_parent:
+  named_detached_parent:
     type: string
     default: ""
     description: >
@@ -52,7 +52,7 @@ steps:
                 echo "Can't merge branch into itself! Skipping."
                 exit 0
               fi
-              git checkout<<# parameters.named_detatched_parent >> -f -B << parameters.named_detatched_parent >><</ parameters.named_detatched_parent >> <<parameters.parent>>
+              git checkout<<# parameters.named_detached_parent >> -f -B << parameters.named_detached_parent >><</ parameters.named_detached_parent >> <<parameters.parent>>
               git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> $CHILD_BRANCH
   - when:
       condition:
@@ -67,5 +67,5 @@ steps:
                 echo "Can't merge branch into itself! Skipping."
                 exit 0
               fi
-              git checkout<<# parameters.named_detatched_parent >> -f -B << parameters.named_detatched_parent >><</ parameters.named_detatched_parent >> $PARENT_BRANCH
+              git checkout<<# parameters.named_detached_parent >> -f -B << parameters.named_detached_parent >><</ parameters.named_detached_parent >> $PARENT_BRANCH
               git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> $CHILD_BRANCH

--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -53,7 +53,7 @@ steps:
                 exit 0
               fi
               git checkout<<# parameters.named_detached_parent >> -f -B << parameters.named_detached_parent >><</ parameters.named_detached_parent >> <<parameters.parent>>
-              git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> $CHILD_BRANCH
+              git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> -m "merge-with-parent" $CHILD_BRANCH
   - when:
       condition:
         not: <<parameters.parent>>
@@ -68,4 +68,4 @@ steps:
                 exit 0
               fi
               git checkout<<# parameters.named_detached_parent >> -f -B << parameters.named_detached_parent >><</ parameters.named_detached_parent >> $PARENT_BRANCH
-              git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> $CHILD_BRANCH
+              git merge<<# parameters.no_fast_forward >> --no-ff<</ parameters.no_fast_forward >><<# parameters.no_commit >> --no-commit<</ parameters.no_commit >> -m "merge-with-parent" $CHILD_BRANCH


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This should fix #31, so non-fast-forward merges work even when `no-commit` (added in #28) is not set.

It also fixes a typo (`detatched`) from #28.

### Description

* Add `-m "merge-with-parent"` to merge-with-parent's `merge` command, so it does not die when there is no EDITOR available.
* Fix `detatched` typo.