### PR TITLE
[semver:patch] Fix for merge-with-parent `Set Git identity` step

### DIFF
--- a/src/commands/merge-with-parent.yml
+++ b/src/commands/merge-with-parent.yml
@@ -32,8 +32,8 @@ steps:
   - run:
       name: Set Git identity
       command: |
-        USER_EMAIL=$(git config --get user.email)
-        USER_NAME=$(git config --get user.name)
+        USER_EMAIL=$(git config --get user.email || true)
+        USER_NAME=$(git config --get user.name || true)
 
         if [ "$USER_EMAIL" = "" ]; then
           git config user.email "circleci@example.com"


### PR DESCRIPTION
### Checklist

<!--
  thank you for contributing to CircleCI Orbs!
  before submitting your a request, please go through the following
  items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

Step `Set Git Identity` fails when there's no preconfigured Git identity

### Description

Bugfix for Issue #33 - prevent non-zero error code returned by  `git config --get` command from failing the step.